### PR TITLE
refactored api-versioning. 

### DIFF
--- a/Config/apiversions.json
+++ b/Config/apiversions.json
@@ -1,26 +1,6 @@
 [
     {
-        "uri": "https://management.azure.com/*/providers/Microsoft.Compute/*",
+        "ProviderName": "Microsoft.Compute",
         "api-version": "2015-05-01-preview"
     }
-    ,
-	{
-		"uri": "https://management.azure.com/subscriptions",
-		"api-version": "2015-01-01"
-	}
-	,
-    	{
-		"uri": "https://management.azure.com/subscriptions/*",
-		"api-version": "2015-01-01"
-	}
-	,
-	{
-		"uri": "https://management.azure.com/tenants",
-		"api-version": "2015-01-01"
-	}
-	,
-	{
-		"uri": "https://management.azure.com/subscriptions/*/resourcegroups",
-		"api-version": "2015-01-01"
-	}
 ]

--- a/Rest/Post-InternalRest.ps1
+++ b/Rest/Post-InternalRest.ps1
@@ -9,6 +9,8 @@ Function Post-InternalRest
 		[Parameter(Mandatory=$false)]
         $ApiVersion,
         [Parameter(Mandatory=$false)]
+        $ProviderName,
+        [Parameter(Mandatory=$false)]
         $QueryStrings,
 		[Parameter(Mandatory=$false)]
 		[PsObject]$Data,
@@ -22,19 +24,42 @@ Function Post-InternalRest
 	
 	$ApiVersions = Get-Content (Join-Path $Script:ThisModulePath "Config\Apiversions.json") -Raw| convertfrom-Json
 	
-	if ($ApiVersion -eq $null)
+    if (($ApiVersion -eq $null) -and ($ProviderName -ne $null))
+    {
+        #Lookup the api version
+        $ApiVersion = $ApiVersions | where {$_.ProviderName -eq $ProviderName} | Select -expandProperty "api-version"
+    }
+    Elseif (($ApiVersion -eq $null) -and ($ProviderName -eq $null))
+    {
+        Write-error "Neither apiversion or providername was specified. "
+        return
+        
+    }
+    ElseIf ($ApiVersion)
+    {
+        #All good
+    }
+    Else
 	{
-        $ThisApiVersion = @()
-		$ThisApiVersion += $ApiVersions |where {$Uri -match $_.Uri}
-		if ($ThisApiVersion.count -ne 1)
-		{
-			Write-error "zero or multiple api versions found for url $uri"
-			Return
-		}
-		Else
-		{
-			$ApiVersion = $ThisApiVersion."api-version"
-		}
+        #Best-efford attempt to get the apiversion
+        Foreach ($ApiVersionEntry in $ApiVersions)
+        {
+            if ($Uri -match $ApiVersionEntry.ProviderName)
+            {
+                $ApiVersion = $ApiVersionEntry."api-version"
+            }
+        }
+    
+        if ($apiversion)
+        {
+            Write-warning "Best-efford attempt to figure out the api-version resulted in version $ApiVersion. This may be incorrect"
+        }        
+        Else
+        {
+            Write-error "Could not calculate api-version. The calling function should specify providername or apiversion."
+            return
+        }        
+        
 	}
 	
 	if ($BearerToken -eq $null)

--- a/Rest/Wait-ArmOperation.ps1
+++ b/Rest/Wait-ArmOperation.ps1
@@ -3,7 +3,8 @@ Function Wait-ArmOperation
     Param (
         $Uri,
         $InProgressStatus=202,
-        $FinishedStatus=200
+        $FinishedStatus=200,
+        $ApiVersion
     )
     
     $Counter = 1
@@ -14,7 +15,7 @@ Function Wait-ArmOperation
         $nowtime = Get-Date
         $ElapsedTime = $nowtime - $OperationStart
         Write-Verbose "Waiting for arm operation (elapsed seconds: $($ElapsedTime.Totalseconds))"
-        $OperationResult = Get-InternalRest -Uri $Uri -ReturnFull $true
+        $OperationResult = Get-InternalRest -Uri $Uri -ReturnFull $true -ApiVersion $ApiVersion
         if ($OperationResult.StatusCode -eq $FinishedStatus)
         {
             #Arm Operation done


### PR DESCRIPTION
Less elegant, but more robust (get-internalRest now requires either apiversion or providername)
