### PR TITLE
refactored api-versioning. 

### DIFF
--- a/ResourceGroup/Get-ArmResourceGroup.ps1
+++ b/ResourceGroup/Get-ArmResourceGroup.ps1
@@ -42,13 +42,13 @@ Function Get-ArmResourceGroup
         {
             $Uri = "$Baseuri/$Name"
             #Name is specified, so we assume a single item
-            $ResultResourceGroups = Get-InternalRest -Uri $Uri -ReturnType "Blue.ResourceGroup" -ReturnTypeSingular $true
+            $ResultResourceGroups = Get-InternalRest -Uri $Uri -ReturnType "Blue.ResourceGroup" -ReturnTypeSingular $true -apiversion "2015-01-01"
         }
         Else
         {
             $Uri = $Baseuri
             #Name is not specified, so we assume multiple items returned.
-            $ResultResourceGroups = Get-InternalRest -Uri $Uri -ReturnType "Blue.ResourceGroup" -ReturnTypeSingular $false
+            $ResultResourceGroups = Get-InternalRest -Uri $Uri -ReturnType "Blue.ResourceGroup" -ReturnTypeSingular $false -apiversion "2015-01-01"
         }
         
         if ($ResultResourceGroups)

--- a/ResourceGroup/New-ArmResourceGroup.ps1
+++ b/ResourceGroup/New-ArmResourceGroup.ps1
@@ -28,7 +28,7 @@ Function New-ArmResourceGroup
             $Data | add-member -MemberType NoteProperty -Name tags -Value $Tags
         }
 		$Uri = "https://management.azure.com/subscriptions/$($script:CurrentSubscriptionId)/resourcegroups/$Name"
-		$RG = Post-InternalRest -uri $Uri -Data $Data -method "Put" -ReturnType "Blue.ResourceGroup" -ReturnTypeSingular $true
+		$RG = Post-InternalRest -uri $Uri -Data $Data -method "Put" -ReturnType "Blue.ResourceGroup" -ReturnTypeSingular $true -apiversion "2015-01-01"
 	}
     End
     {

--- a/ResourceGroup/Remove-ArmResourceGroup.ps1
+++ b/ResourceGroup/Remove-ArmResourceGroup.ps1
@@ -44,7 +44,7 @@ Function Remove-ArmResourceGroup
         if($PSCmdlet.ShouldProcess($script:CurrentSubscriptionId,$ProcessText))
         {
             
-            $Result = Get-InternalRest -Uri $Uri -method "Delete" -ReturnFull $true
+            $Result = Get-InternalRest -Uri $Uri -method "Delete" -ReturnFull $true  -apiversion "2015-01-01"
             
             #The "Location" Header of the returned object is the URL to poll in order to check for deletion status
             #The status code returned when hitting that URL will change from 202 to 200 when the operation has completed
@@ -57,7 +57,7 @@ Function Remove-ArmResourceGroup
             Else
             {
                 #Poll the operationuri to wait for the thing to complete
-                Wait-ArmOperation -Uri $OperationUri
+                Wait-ArmOperation -Uri $OperationUri -apiversion "2015-01-01"
             }
             
         }


### PR DESCRIPTION
Less elegant, but more robust (get-internalRest now requires either apiversion or providername)
