### PR TITLE
Always try tokencache first

### DIFF
--- a/Auth/Connect-ArmSubscription.ps1
+++ b/Auth/Connect-ArmSubscription.ps1
@@ -34,7 +34,7 @@ Function Connect-ArmSubscription
 		}
         Else
         {
-            $Params.Add("PromptBehavior","Auto")
+            $Params.Add("PromptBehavior","Suppress")
         }
 
         $Params.Add("LoginUrl",$Script:LoginUrl)


### PR DESCRIPTION
if -forceshowui is not specified, try to login first with whatever is in the tokencache. This enables a completely non-gui, non-parameter experience for connect-armsubscription if the tokencache is already filled with valid things.
