### PR TITLE
Bugfix for multiple subs found / one specified error

### DIFF
--- a/Auth/Connect-ArmSubscription.ps1
+++ b/Auth/Connect-ArmSubscription.ps1
@@ -206,6 +206,16 @@ Function Connect-ArmSubscription
             {
                 Write-Error "specified subscriptionId $SubscriptionId was not found for tenant" -ErrorAction Stop
             }
+            
+            #requested Subscription id found in the map, add that one
+            $RequestedSub = $TenantAuthMap | where {$_.SubscriptionId -eq $SubscriptionId}
+            $script:AuthToken = $RequestedSub.AccessToken
+            $Script:RefreshToken = $RequestedSub.RefreshToken
+            $script:TokenExpirationUtc = $RequestedSub.Expiry
+            $script:CurrentSubscriptionId = $RequestedSub.SubscriptionId
+            $ThisSubscription =  $RequestedSub
+
+
         }
         ElseIf ($TenantAuthMap.count -eq 1)
         {


### PR DESCRIPTION
This fixes the bug where if the subscriptionid param was specified and the user had access to more than one subscriotion all h broke loose.
