### PR TITLE
fixed issue where refreshtoken wasnt properly used

### DIFF
--- a/Auth/Connect-ArmSubscription.ps1
+++ b/Auth/Connect-ArmSubscription.ps1
@@ -81,8 +81,11 @@ Function Connect-ArmSubscription
             #Remove the current subscription object from the array
             
             $CurrentSub = $Script:AllSubscriptions | where {$_.SubscriptionId -eq $script:CurrentSubscriptionId}
-            $Script:AllSubscriptions = $Script:AllSubscriptions | where {$_.SubscriptionId -ne $script:CurrentSubscriptionId}
             
+            #Workaround to make sure "allsubscriptions" is an array an not an object, even if it only contains one object
+            $TempAllSubs = @()
+            $TempAllSubs += $Script:AllSubscriptions | where {$_.SubscriptionId -ne $script:CurrentSubscriptionId}
+            $Script:AllSubscriptions = $TempAllSubs
 
             $SubObj = "" | Select SubscriptionId,TenantId,AccessToken,RefreshToken, Expiry, SubscriptionObject, DisplayName, State, LoginUrl
             $subobj.SubscriptionId = $script:CurrentSubscriptionId
@@ -192,7 +195,8 @@ Function Connect-ArmSubscription
         }
     
         #Add all subscriptions to global var
-        $Script:AllSubscriptions = $TenantAuthMap
+        $Script:AllSubscriptions = @()
+        $Script:AllSubscriptions += $TenantAuthMap
 	
         #Figure out which subscription to choose
         if ($TenantAuthMap.count -eq 0)

--- a/Auth/Test-InternalArmConnection.ps1
+++ b/Auth/Test-InternalArmConnection.ps1
@@ -10,16 +10,17 @@ Function Test-InternalArmConnection
 		
 		#Test that we can reach the current subscription
 		$Uri = "https://management.azure.com/subscriptions/$($script:CurrentSubscriptionId)"
-		Try 
-		{
-			$Result =Get-InternalRest -Uri $Uri -apiversion "2015-01-01"
-			$AuthSuccess = $true
-		}
-		Catch
-		{
-			$AuthSuccess = $false
-		}
+        $Result =Get-InternalRest -Uri $Uri -apiversion "2015-01-01" -ErrorAction SilentlyContinue -ErrorVariable autherror
 		
+        if ($Autherror)
+        {
+            $AuthSuccess = $false
+        }
+        Else
+        {
+            $AuthSuccess = $true
+        }
+        
 		
         if ($AuthSuccess -eq $false)
         {

--- a/Rest/Get-InternalRest.ps1
+++ b/Rest/Get-InternalRest.ps1
@@ -67,9 +67,11 @@ Function Get-InternalRest
 	if ($BearerToken -eq $null)
 	{
 		$BearerToken = $script:AuthToken
-		if (-not (Test-InternalTokenNotExpired -Token $BearerToken)) {
+		<#
+        if (-not (Test-InternalTokenNotExpired -Token $BearerToken)) {
             Write-Error -Message "Authentication token has expired. Run Connect-ArmSubscription to acquire a new one" -ErrorAction Stop
         }
+        #>
 		$TokenExpiry = $script:TokenExpirationUtc
 		
 	}


### PR DESCRIPTION
This fixed the condition where when the authtoken timed out (60 minutes after logging on) the code wasn't able to refresh its token without throwing errors. The module should now work, also on operations which extend past 60 minutes.
